### PR TITLE
Check that key lengths are properly enforced

### DIFF
--- a/java/src/main/java/net/snowflake/floe/Floe.java
+++ b/java/src/main/java/net/snowflake/floe/Floe.java
@@ -43,6 +43,8 @@ public class Floe {
         throw new IllegalArgumentException("Header is too long");
       }
       return new FloeEncryptorImpl(parameterSpec, floeKey, floeIv, floeAad, header.array(), random);
+    } catch (final RuntimeException ex) {
+      throw ex;
     } catch (Exception e) {
       throw new FloeException(e);
     }


### PR DESCRIPTION
Check that key lengths are properly enforced.

I also changed how exceptions are returned from the encryptor flow to more closely replicate how they are done from the encryptor flow.