### PR TITLE
SNOW-0000: Fix rotation mask in Java

### DIFF
--- a/java/src/main/java/net/snowflake/floe/Aead.java
+++ b/java/src/main/java/net/snowflake/floe/Aead.java
@@ -10,7 +10,7 @@ public enum Aead {
   private final int keyLength;
   private final int ivLength;
   private final int authTagLength;
-  private final int keyRotationMask;
+  private final long keyRotationMask;
   private final long maxSegmentNumber;
   private final Supplier<AeadProvider> aeadProvider;
 
@@ -20,7 +20,7 @@ public enum Aead {
       int keyLength,
       int ivLength,
       int authTagLength,
-      int keyRotationMask,
+      int maskBits,
       long maxSegmentNumber,
       Supplier<AeadProvider> aeadProvider) {
     this.jceKeyTypeName = jceKeyTypeName;
@@ -28,7 +28,10 @@ public enum Aead {
     this.id = id;
     this.ivLength = ivLength;
     this.authTagLength = authTagLength;
-    this.keyRotationMask = keyRotationMask;
+    long tmpMask = 1L << maskBits;
+    tmpMask--;
+    tmpMask = ~tmpMask;
+    this.keyRotationMask = tmpMask;
     this.maxSegmentNumber = maxSegmentNumber;
     this.aeadProvider = aeadProvider;
   }
@@ -60,7 +63,7 @@ public enum Aead {
     return authTagLength;
   }
 
-  int getKeyRotationMask() {
+  long getKeyRotationMask() {
     return keyRotationMask;
   }
 

--- a/java/src/main/java/net/snowflake/floe/FloeParameterSpec.java
+++ b/java/src/main/java/net/snowflake/floe/FloeParameterSpec.java
@@ -16,7 +16,7 @@ public class FloeParameterSpec {
   private final Hash hash;
   private final int encryptedSegmentLength;
   private final int floeIvLength;
-  private final Integer keyRotationModuloOverride;
+  private final Long keyRotationMaskOverride;
   private final Long maxSegmentNumberOverride;
   private final byte[] encodedParams;
 
@@ -35,13 +35,13 @@ public class FloeParameterSpec {
       Hash hash,
       int encryptedSegmentLength,
       int floeIvLength,
-      Integer keyRotationModuloOverride,
+      Long keyRotationMaskOverride,
       Long maxSegmentNumberOverride) {
     this.aead = aead;
     this.hash = hash;
     this.encryptedSegmentLength = encryptedSegmentLength;
     this.floeIvLength = floeIvLength;
-    this.keyRotationModuloOverride = keyRotationModuloOverride;
+    this.keyRotationMaskOverride = keyRotationMaskOverride;
     this.maxSegmentNumberOverride = maxSegmentNumberOverride;
     if (encryptedSegmentLength <= 0) {
       throw new IllegalArgumentException("encryptedSegmentLength must be > 0");
@@ -94,8 +94,8 @@ public class FloeParameterSpec {
     return encryptedSegmentLength - aead.getIvLength() - aead.getAuthTagLength() - Floe.SEGMENT_SIZE_MARKER_LENGTH;
   }
 
-  int getKeyRotationMask() {
-    return Optional.ofNullable(keyRotationModuloOverride).orElse(aead.getKeyRotationMask());
+  long getKeyRotationMask() {
+    return Optional.ofNullable(keyRotationMaskOverride).orElse(aead.getKeyRotationMask());
   }
 
   long getMaxSegmentNumber() {
@@ -118,14 +118,14 @@ public class FloeParameterSpec {
         && floeIvLength == that.floeIvLength
         && aead == that.aead
         && hash == that.hash
-        && Objects.equals(keyRotationModuloOverride, that.keyRotationModuloOverride)
+        && Objects.equals(keyRotationMaskOverride, that.keyRotationMaskOverride)
         && Objects.equals(maxSegmentNumberOverride, that.maxSegmentNumberOverride)
         && Objects.deepEquals(encodedParams, that.encodedParams);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(aead, hash, encryptedSegmentLength, floeIvLength, keyRotationModuloOverride, maxSegmentNumberOverride, Arrays.hashCode(encodedParams));
+    return Objects.hash(aead, hash, encryptedSegmentLength, floeIvLength, keyRotationMaskOverride, maxSegmentNumberOverride, Arrays.hashCode(encodedParams));
   }
 
   @Override

--- a/java/src/test/java/net/snowflake/floe/FloeEncryptorImplTest.java
+++ b/java/src/test/java/net/snowflake/floe/FloeEncryptorImplTest.java
@@ -29,7 +29,7 @@ class FloeEncryptorImplTest {
             Hash.SHA384,
             12345678,
             32,
-            4,
+            -4L,
             1L << 40);
     Floe floe = Floe.getInstance(parameterSpec);
     try (FloeEncryptor encryptor = floe.createEncryptor(new SecretKeySpec(new byte[32], "FLOE"), "test aad".getBytes(StandardCharsets.UTF_8), random)) {
@@ -68,7 +68,7 @@ class FloeEncryptorImplTest {
   void shouldThrowExceptionOnMaxSegmentReached() throws Exception {
     FloeParameterSpec parameterSpec =
         new FloeParameterSpec(
-            Aead.AES_GCM_256, Hash.SHA384, 40,32, 20, 3L);
+            Aead.AES_GCM_256, Hash.SHA384, 40,32, Aead.AES_GCM_256.getKeyRotationMask(), 3L);
     Floe floe = Floe.getInstance(parameterSpec);
     try (FloeEncryptor encryptor = floe.createEncryptor(secretKey, aad)) {
       byte[] plaintext = new byte[8];

--- a/java/src/test/java/net/snowflake/floe/KatTest.java
+++ b/java/src/test/java/net/snowflake/floe/KatTest.java
@@ -98,7 +98,7 @@ class KatTest {
             "pub_java_GCM256_IV256_1M"
         ),
         Arguments.of(
-            new FloeParameterSpec(Aead.AES_GCM_256, Hash.SHA384, 40, 32, 4, 1L << 40),
+            new FloeParameterSpec(Aead.AES_GCM_256, Hash.SHA384, 40, 32, -4L, 1L << 40),
             "pub_java_rotation"
         )
     );


### PR DESCRIPTION
Current code incorrectly results in rotating the key every 20 segments rather than 2^20 segments. I've pulled in equivalent code from the reference implementation.

https://github.com/Snowflake-Labs/floe-specification/blob/b2380dbb8ee45b0f27b1007545aa9fb2c368f90f/java/lib/src/main/java/com/snowflake/floe/FloeAead.java#L41-L44